### PR TITLE
Implement "AsciiPixel" for desktop prototyping

### DIFF
--- a/hello_neopixel/asciipixel.py
+++ b/hello_neopixel/asciipixel.py
@@ -121,5 +121,10 @@ class AsciiPixel:
         ]
 
         print(
-            header + spacer + spacer.join(text_pixels) + spacer, **print_kwargs
+            header
+            + spacer
+            + spacer.join(text_pixels)
+            + spacer
+            + RESET_SEQUENCE,
+            **print_kwargs
         )

--- a/hello_neopixel/asciipixel.py
+++ b/hello_neopixel/asciipixel.py
@@ -72,7 +72,6 @@ class AsciiPixel:
                                       be changed later.
 
         """
-        self.n = n_pixels  # TODO: make this a property?
         self.animate_mode = animate
         self._background_color = strip_color
         self._pixel_spacing = pixel_spacing
@@ -90,6 +89,13 @@ class AsciiPixel:
         #       alternatively, is there a more primitive way to hint at
         #       "tuple of three ints"?
         self._pixels[index] = value  # type: ignore[assignment]
+
+    def __len__(self) -> int:
+        return len(self._pixels)
+
+    @property
+    def n(self) -> int:
+        return len(self)
 
     def write(self, output_to=None):  # TODO: type hint?
         """Emulation of the NeoPixel write function which, in this case,

--- a/hello_neopixel/asciipixel.py
+++ b/hello_neopixel/asciipixel.py
@@ -1,0 +1,110 @@
+"""Virtual terminal-based NeoPixel implementation"""
+
+RESET_SEQUENCE = "\033[0m"
+PIXEL_CHARACTER = "\u2b24"  # https://www.compart.com/en/unicode/U+2B24
+
+
+def convert_rgb_to_ansi_escape(color: tuple, which_color: str) -> str:
+    """Create an ANSI escape sequence to color the text and background as
+    specified
+
+    Args:
+        color : tuple of three ints
+            The RGB value for the color.
+        which_color : str
+            Which color you're looking to set. Must either be one of:
+                - "background"
+                - "text" / "foreground"
+
+    Returns:
+        str : the ANSI escape sequence for coloring the background and text
+              as specified
+
+    Notes:
+        Never forget to end your text sequence with the RESET_SEQUENCE!
+    """
+    if which_color == "background":
+        selector_code = "48"
+    elif which_color in ("text", "foreground"):
+        selector_code = "38"
+    else:
+        message = (
+            "This method only supports setting background and"
+            " foreground / text colors"
+        )
+        raise ValueError(message)
+
+    return "\033[{};2;{};{};{}m".format(selector_code, *color)
+
+
+class AsciiPixel:
+    """Virtual light strip where the colors of each pixel get rendered as a
+    character in the terminal.
+
+    Attributes:
+        n (int) : the number of pixels
+        animate_mode (bool) : when True, the "strip" will be printed with a
+                              carriage return, but no newline, so as to
+                              animate in place
+
+    Notes:
+        Requires your terminal to support TrueColor
+    """
+
+    def __init__(
+        self,
+        n_pixels: int,
+        strip_color: tuple = (0, 0, 0),
+        pixel_spacing: int = 1,
+        animate: bool = False,
+    ) -> None:
+        """Initialize the virtual light strip
+
+        Args:
+            n_pixels (int) : the number of pixels in your virtual strip
+            strip_color (tuple of three ints, optional) :
+                the "background" RGB color (color between pixels) of your
+                virtual light strip. Default is black (0, 0, 0).
+            pixel_spacing (int, optional): the number of characters between each
+                                           pixel. Default is 1.
+            animate (bool, optional): whether to initialize the strip in
+                                      "animate mode" (print without newline).
+                                      Default is False, and this can always
+                                      be changed later.
+
+        """
+        self.n = n_pixels  # TODO: make this a property?
+        self.animate_mode = animate
+        self._background_color = strip_color
+        self._pixel_spacing = pixel_spacing
+        self._pixels = [(0, 0, 0) for _ in range(n_pixels)]
+
+    def __iter__(self):
+        for pixel in self._pixels:
+            yield pixel
+
+    def __getitem__(self, index: int) -> tuple:
+        return self._pixels[index]
+
+    def __setitem__(self, index: int, value: tuple) -> None:
+        # TODO: is typing available for uPython?
+        #       alternatively, is there a more primitive way to hint at
+        #       "tuple of three ints"?
+        self._pixels[index] = value  # type: ignore[assignment]
+
+    def write(self):
+        spacer = " " * self._pixel_spacing
+
+        header = convert_rgb_to_ansi_escape(
+            self._background_color, "background"
+        )
+
+        text_pixels = [
+            convert_rgb_to_ansi_escape(pixel_rgb, "text") + PIXEL_CHARACTER
+            for pixel_rgb in self
+        ]
+
+        print(
+            header + spacer + spacer.join(text_pixels) + spacer,
+            end="\r" if self.animate_mode else "\n",
+        )

--- a/hello_neopixel/asciipixel.py
+++ b/hello_neopixel/asciipixel.py
@@ -1,5 +1,4 @@
 """Virtual terminal-based NeoPixel implementation"""
-
 RESET_SEQUENCE = "\033[0m"
 PIXEL_CHARACTER = "\u2b24"  # https://www.compart.com/en/unicode/U+2B24
 
@@ -92,8 +91,25 @@ class AsciiPixel:
         #       "tuple of three ints"?
         self._pixels[index] = value  # type: ignore[assignment]
 
-    def write(self):
+    def write(self, output_to=None):  # TODO: type hint?
+        """Emulation of the NeoPixel write function which, in this case,
+        renders the virtual strip to stdout
+
+        Args:
+            output_to (stream, optional):  If you'd like to display the virtual
+                                           pixel to somewhere else besides
+                                           stdout, provide your desired
+                                           output stream to this argument.
+
+        Returns:
+            None
+        """
         spacer = " " * self._pixel_spacing
+        print_kwargs = {}
+        if self.animate_mode:
+            print_kwargs["end"] = "\r"
+        if output_to is not None:
+            print_kwargs["file"] = output_to
 
         header = convert_rgb_to_ansi_escape(
             self._background_color, "background"
@@ -105,6 +121,5 @@ class AsciiPixel:
         ]
 
         print(
-            header + spacer + spacer.join(text_pixels) + spacer,
-            end="\r" if self.animate_mode else "\n",
+            header + spacer + spacer.join(text_pixels) + spacer, **print_kwargs
         )

--- a/hello_neopixel/tests/__init__.py
+++ b/hello_neopixel/tests/__init__.py
@@ -1,6 +1,7 @@
 from unittest import main
 
 from .test_animations import *  # noqa: F401, F403
+from .test_asciipixel import *  # noqa: F401, F403
 from .test_utils import *  # noqa: F401, F403
 
 if __name__ == "__main__":

--- a/hello_neopixel/tests/test_animations.py
+++ b/hello_neopixel/tests/test_animations.py
@@ -1,4 +1,4 @@
-"""Placeholder for tests for the various animations.
+"""Tests for the various animations.
 Of course, the best test of any animation is how it looks on the strip."""
 from unittest import TestCase, main
 
@@ -79,8 +79,8 @@ class TestRandomCycle(TestCase):
             ), "pixel {} was not blanked".format(i)
 
     def test_clear_after_false_leaves_pixels_illuminated(self):
-        """taking advantage of the fact that all random colors are max brightness
-        and saturation"""
+        """taking advantage of the fact that all random colors are
+        max brightness and saturation"""
         fake_neopixel = FakeNeoPixel(5)
         ani.random_cycle(
             fake_neopixel, runtime=0.1, frame_rate=100, clear_after=False

--- a/hello_neopixel/tests/test_asciipixel.py
+++ b/hello_neopixel/tests/test_asciipixel.py
@@ -1,0 +1,165 @@
+from io import StringIO
+from unittest import TestCase, main
+
+from hello_neopixel import asciipixel
+
+__all__ = ["TestConvertRGBToANSIEscape", "TestAsciiPixel"]
+
+
+class TestConvertRGBToANSIEscape(TestCase):
+    def test_background_coloring(self):
+
+        self.assertEqual(
+            asciipixel.convert_rgb_to_ansi_escape((123, 234, 56), "background"),
+            "\033[48;2;123;234;56m",
+        )
+
+    def test_text_coloring(self):
+        for color_arg in ("foreground", "text"):
+            self.assertEqual(
+                asciipixel.convert_rgb_to_ansi_escape((30, 0, 255), color_arg),
+                "\033[38;2;30;0;255m",
+            )
+
+    def test_unrecognized_color_arg_raises_value_error(self):
+        for color_arg in ("baground", "fg", "character", "all", "blink"):
+            self.assertRaises(
+                ValueError,
+                asciipixel.convert_rgb_to_ansi_escape,
+                (6, 6, 6),
+                color_arg,
+            )
+
+    def test_color_arg_is_required(self):
+        self.assertRaises(
+            TypeError, asciipixel.convert_rgb_to_ansi_escape, (255, 255, 255)
+        )
+
+
+class TestAsciiPixel(TestCase):
+    def test_setting_strip_length(self):
+        light_strip = asciipixel.AsciiPixel(4)
+        self.assertEqual(light_strip.n, 4)
+        self.assertEqual(len(light_strip), 4)
+
+    def test_default_pixel_value_is_black(self):
+        black = (0, 0, 0)
+        light_strip = asciipixel.AsciiPixel(7)
+        for i in range(7):
+            assert (
+                light_strip[i] == black
+            ), "Pixel {} was initialized to {}".format(i, light_strip[i])
+
+    def test_writes_the_correct_number_of_pixels(self):
+        testing_io = StringIO()
+        light_strip = asciipixel.AsciiPixel(16)
+        for i in range(16):
+            light_strip[i] = (
+                255 * (i % 3 == 0),
+                255 * (i % 3 == 1),
+                255 * (i % 3 == 2),
+            )
+
+        light_strip.write(output_to=testing_io)
+
+        testing_io.seek(0)  # rewind
+        output = testing_io.read()
+        self.assertEqual(output.count(asciipixel.PIXEL_CHARACTER), 16)
+
+    def test_writes_the_correct_number_and_size_of_spacers(self):
+        testing_io = StringIO()
+        light_strip = asciipixel.AsciiPixel(7, pixel_spacing=4)
+        for i in range(7):
+            light_strip[i] = ((400 * i) % 255, (70 * i + 160) % 255, 0)
+
+        light_strip.write(output_to=testing_io)
+
+        testing_io.seek(0)  # rewind
+        output = testing_io.read()
+        self.assertEqual(output.count("    "), light_strip.n + 1)
+        # if spacers were larger than intended, the above might still be true
+        self.assertEqual(output.count("     "), 0)
+
+    def test_default_writes_end_in_newline(self):
+        testing_io = StringIO()
+        light_strip = asciipixel.AsciiPixel(2)
+        for i in range(2):
+            light_strip[i] = (128, 128, 255)
+
+        light_strip.write(output_to=testing_io)
+
+        testing_io.seek(0)  # rewind
+        output = testing_io.read()
+        assert output.endswith("\n"), (
+            "Write sequence was" "\n{}" "\nand didn't end with a newline"
+        ).format(repr(output))
+
+    def test_animate_mode_writes_end_in_carriage_return(self):
+        testing_io = StringIO()
+        light_strip = asciipixel.AsciiPixel(2, animate=True)
+        for i in range(2):
+            light_strip[i] = (0, 255, 0)
+
+        light_strip.write(output_to=testing_io)
+
+        testing_io.seek(0)  # rewind
+        output = testing_io.read()
+        assert output.endswith("\r"), (
+            "Write sequence was"
+            "\n{}"
+            "\nand didn't end with a carriage return"
+        ).format(repr(output))
+
+    def test_animate_mode_can_be_altered_mid_animation(self):
+        testing_io = StringIO()
+        light_strip = asciipixel.AsciiPixel(2, animate=True)
+        for i in range(2):
+            light_strip[i] = (255, 255, 255)
+
+        light_strip.write(output_to=testing_io)
+
+        light_strip.animate_mode = False
+
+        for i in range(2):
+            light_strip[i] = (0, 0, 0)
+
+        light_strip.write(output_to=testing_io)
+
+        testing_io.seek(0)  # rewind
+        output = testing_io.read()
+        frames = [
+            "\x1b[48" + frame
+            # bg sequence should only be written once per frame
+            # (I guess this tests that)
+            for frame in output.split("\x1b[48")[1:]
+        ]
+        for frame_num, expected_end in enumerate(("\r", "\n")):
+            frame = frames[frame_num]
+            assert frame.endswith(expected_end), (
+                "Frame {} was\n{}\nand didn't end with {}"
+            ).format(frame_num, repr(frame), repr(expected_end))
+
+    def test_writes_end_in_reset_sequence(self):
+        testing_io = StringIO()
+        for animate in (True, False):
+            light_strip = asciipixel.AsciiPixel(2, animate=animate)
+            for i in range(2):
+                light_strip[i] = (255, 0, 0)
+
+            light_strip.write(output_to=testing_io)
+
+            testing_io.seek(0)  # rewind
+            output = testing_io.read()
+            assert output[:-1].endswith(  # ignore newline / carriage return
+                asciipixel.RESET_SEQUENCE
+            ), (
+                "With animate={}, write sequence was"
+                "\n{}"
+                "\nand didn't end in the reset sequence"
+            ).format(
+                animate, repr(output)
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

This PR introduces the a class called `AsciiPixel`, which implements the main API elements of Adafruit's MicroPython / CircuitPython [`NeoPixel`](https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel/blob/6.0.2/neopixel.py) class to render an RGB "light strip" to any True Color-compatible terminal. For example, taking the `main.py` example from [the last release](https://github.com/OpenBagTwo/HelloNeoPixel/releases/tag/v2021.3.8), we can swap out the `NeoPixel` for an `AsciiPixel` strip:
```
from hello_neopixel import random_cycle
from hello_neopixel.asciipixel import AsciiPixel

N_PIXELS = 20


light_strip = AsciiPixel(N_PIXELS, animate=True)

random_cycle(light_strip)
```
which, when run, will render as:

![AsciiPixel demo](https://user-images.githubusercontent.com/66568922/111086419-6d8f6c00-84f2-11eb-9d5a-3cae7ae84c5e.gif)

The `AsciiPixel` class can be configured with different background colors and spacings between pixels, and can be run in either one-line-per-frame mode, or, more appealingly, the "animated" mode demoed above.

## Known Issues / Tech Debt

Really coming up against the limits of type hinting [without the `typing` module](https://github.com/micropython/micropython-lib/issues/190)

## Validation Performed

- Demo above ran using `v2021.3.8+4.gd9c02f4` (on x64-Linux)
- [All tests pass](https://github.com/OpenBagTwo/HelloNeoPixel/files/6137740/test_log.log)
 against:
     - HelloNeopixel v2021.3.8+4.gd9c02f4
    - MicroPython 3d45bca-dirty on 2021-02-02; linux version
- All [new tests](https://github.com/OpenBagTwo/HelloNeoPixel/issues/2) pass when running
    - HelloNeopixel v2021.3.8+4.gd9c02f4
    - MicroPython v1.14 on 2021-02-02; ESP32 module (spiram) with ESP32